### PR TITLE
[RTC-102] Fix screensharing freezes

### DIFF
--- a/integration_test/test_videoroom/test/integration/simulcast_test.exs
+++ b/integration_test/test_videoroom/test/integration/simulcast_test.exs
@@ -41,7 +41,7 @@ defmodule TestVideoroom.Integration.SimulcastTest do
   # video low - 150kbps
   # video medium - 500kbps
   # video high - 1500kbps
-  @probe_times %{low_to_medium: 16_000, low_to_high: 31_000, nil_to_high: 55_000}
+  @probe_times %{low_to_medium: 15_000, low_to_high: 30_000, nil_to_high: 50_000}
 
   # FIXME
   # this test shouldn't pass

--- a/integration_test/test_videoroom/test/integration/simulcast_test.exs
+++ b/integration_test/test_videoroom/test/integration/simulcast_test.exs
@@ -17,7 +17,7 @@ defmodule TestVideoroom.Integration.SimulcastTest do
   @simulcast_inbound_stats "simulcast-inbound-stats"
   @simulcast_outbound_stats "simulcast-outbound-stats"
   @browser_options %{count: 1, headless: true}
-  @max_test_duration 400_000
+  @max_test_duration 460_000
 
   # we want to get stats for at least 30 seconds
   # to ensure that the variant won't switch
@@ -31,9 +31,9 @@ defmodule TestVideoroom.Integration.SimulcastTest do
   # time needed to request and receive a variant
   @variant_request_time 2_000
   # max time needed to recognize variant as inactive
-  @variant_inactivity_time 2_000
+  @variant_inactivity_time 4_000
   # max time needed to recognize variant as active
-  @variant_activity_time 11_000
+  @variant_activity_time 13_000
   # times needed to probe from one resolution to another
   # assumes that audio is present
   # assumes the following max limits:
@@ -41,7 +41,7 @@ defmodule TestVideoroom.Integration.SimulcastTest do
   # video low - 150kbps
   # video medium - 500kbps
   # video high - 1500kbps
-  @probe_times %{low_to_medium: 15_000, low_to_high: 30_000, nil_to_high: 50_000}
+  @probe_times %{low_to_medium: 16_000, low_to_high: 31_000, nil_to_high: 55_000}
 
   # FIXME
   # this test shouldn't pass

--- a/integration_test/test_videoroom/test/integration/simulcast_test.exs
+++ b/integration_test/test_videoroom/test/integration/simulcast_test.exs
@@ -33,7 +33,7 @@ defmodule TestVideoroom.Integration.SimulcastTest do
   # max time needed to recognize variant as inactive
   @variant_inactivity_time 4_000
   # max time needed to recognize variant as active
-  @variant_activity_time 13_000
+  @variant_activity_time 11_000
   # times needed to probe from one resolution to another
   # assumes that audio is present
   # assumes the following max limits:

--- a/lib/membrane_rtc_engine/endpoints/webrtc/variant_tracker.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/variant_tracker.ex
@@ -64,7 +64,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
   """
   @spec check_variant_status(t()) :: {:ok, t()} | {:status_changed, t(), :inactive | :active}
   def check_variant_status(tracker) do
-    if tracker.samples < 1 do
+    if tracker.samples < tracker.required_samples do
       tracker = %__MODULE__{
         tracker
         | activity_cycles: 0,
@@ -89,14 +89,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
   """
   @spec reset(t()) :: t()
   def reset(tracker) do
-    %__MODULE__{tracker | samples: 0, activity_cycles: 0}
+    %__MODULE__{tracker | samples: 0, activity_cycles: 0, inactivity_cycles: 0}
   end
 
   defp maybe_inactive(tracker) do
     if tracker.status == :active and
          tracker.inactivity_cycles == tracker.required_inactivity_cycles do
       Membrane.Logger.debug("Variant #{inspect(tracker.variant)} is inactive.")
-      tracker = %__MODULE__{tracker | status: :inactive, samples: 0}
+      tracker = %__MODULE__{tracker | status: :inactive, inactivity_cycles: 0, samples: 0}
       {:status_changed, tracker, :inactive}
     else
       {:ok, tracker}

--- a/lib/membrane_rtc_engine/endpoints/webrtc/variant_tracker.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/variant_tracker.ex
@@ -67,7 +67,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
     if tracker.samples < tracker.required_samples do
       tracker = %__MODULE__{
         tracker
-        | activity_cycles: 0,
+        | samples: 0,
+          activity_cycles: 0,
           inactivity_cycles: tracker.inactivity_cycles + 1
       }
 
@@ -96,7 +97,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
     if tracker.status == :active and
          tracker.inactivity_cycles == tracker.required_inactivity_cycles do
       Membrane.Logger.debug("Variant #{inspect(tracker.variant)} is inactive.")
-      tracker = %__MODULE__{tracker | status: :inactive, inactivity_cycles: 0, samples: 0}
+      tracker = %__MODULE__{tracker | status: :inactive, inactivity_cycles: 0}
       {:status_changed, tracker, :inactive}
     else
       {:ok, tracker}

--- a/lib/membrane_rtc_engine/endpoints/webrtc/variant_tracker.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/variant_tracker.ex
@@ -14,25 +14,39 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
           variant: String.t(),
           status: :active | :inactive,
           samples: non_neg_integer(),
-          cycles: non_neg_integer(),
+          activity_cycles: non_neg_integer(),
+          inactivity_cycles: non_neg_integer(),
           required_samples: non_neg_integer(),
-          required_cycles: non_neg_integer()
+          required_activity_cycles: non_neg_integer(),
+          required_inactivity_cycles: non_neg_integer()
         }
 
-  @enforce_keys [:variant, :required_samples, :required_cycles]
+  @enforce_keys [
+    :variant,
+    :required_samples,
+    :required_activity_cycles,
+    :required_inactivity_cycles
+  ]
   defstruct @enforce_keys ++
               [
                 status: :active,
                 samples: 0,
-                cycles: 0
+                activity_cycles: 0,
+                inactivity_cycles: 0
               ]
 
-  @spec new(String.t(), non_neg_integer(), non_neg_integer()) :: t()
-  def new(variant, required_samples \\ 5, required_cycles \\ 10) do
+  @spec new(String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: t()
+  def new(
+        variant,
+        required_samples \\ 1,
+        required_activity_cycles \\ 10,
+        required_inactivity_cycles \\ 3
+      ) do
     %__MODULE__{
       variant: variant,
       required_samples: required_samples,
-      required_cycles: required_cycles
+      required_activity_cycles: required_activity_cycles,
+      required_inactivity_cycles: required_inactivity_cycles
     }
   end
 
@@ -50,11 +64,22 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
   """
   @spec check_variant_status(t()) :: {:ok, t()} | {:status_changed, t(), :inactive | :active}
   def check_variant_status(tracker) do
-    if tracker.samples < tracker.required_samples do
-      tracker = %__MODULE__{tracker | samples: 0, cycles: 0}
+    if tracker.samples < 1 do
+      tracker = %__MODULE__{
+        tracker
+        | activity_cycles: 0,
+          inactivity_cycles: tracker.inactivity_cycles + 1
+      }
+
       maybe_inactive(tracker)
     else
-      tracker = %__MODULE__{tracker | samples: 0, cycles: tracker.cycles + 1}
+      tracker = %__MODULE__{
+        tracker
+        | samples: 0,
+          inactivity_cycles: 0,
+          activity_cycles: tracker.activity_cycles + 1
+      }
+
       maybe_active(tracker)
     end
   end
@@ -64,13 +89,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
   """
   @spec reset(t()) :: t()
   def reset(tracker) do
-    %__MODULE__{tracker | samples: 0, cycles: 0}
+    %__MODULE__{tracker | samples: 0, activity_cycles: 0}
   end
 
   defp maybe_inactive(tracker) do
-    if tracker.status == :active do
+    if tracker.status == :active and
+         tracker.inactivity_cycles == tracker.required_inactivity_cycles do
       Membrane.Logger.debug("Variant #{inspect(tracker.variant)} is inactive.")
-      tracker = %__MODULE__{tracker | status: :inactive}
+      tracker = %__MODULE__{tracker | status: :inactive, samples: 0}
       {:status_changed, tracker, :inactive}
     else
       {:ok, tracker}
@@ -78,9 +104,9 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker do
   end
 
   defp maybe_active(tracker) do
-    if tracker.status == :inactive and tracker.cycles == tracker.required_cycles do
+    if tracker.status == :inactive and tracker.activity_cycles == tracker.required_activity_cycles do
       Membrane.Logger.debug("Variant #{inspect(tracker.variant)} is active.")
-      tracker = %__MODULE__{tracker | status: :active, cycles: 0}
+      tracker = %__MODULE__{tracker | status: :active, activity_cycles: 0}
       {:status_changed, tracker, :active}
     else
       {:ok, tracker}

--- a/test/membrane_rtc_engine/webrtc/track_sender_test.exs
+++ b/test/membrane_rtc_engine/webrtc/track_sender_test.exs
@@ -103,7 +103,7 @@ defmodule Membrane.RTC.Engine.WebRTC.TrackSenderTest do
       end)
 
       Enum.each(@variants, fn variant ->
-        assert_sink_event(pipeline, {:sink, variant}, %TrackVariantPaused{}, 3_000)
+        assert_sink_event(pipeline, {:sink, variant}, %TrackVariantPaused{}, 5_000)
       end)
 
       Pipeline.terminate(pipeline, blocking?: true)
@@ -118,7 +118,7 @@ defmodule Membrane.RTC.Engine.WebRTC.TrackSenderTest do
       end)
 
       Enum.each(@variants, fn variant ->
-        assert_sink_event(pipeline, {:sink, variant}, %TrackVariantPaused{}, 3_000)
+        assert_sink_event(pipeline, {:sink, variant}, %TrackVariantPaused{}, 5_000)
       end)
 
       Enum.each(@variants, fn variant ->


### PR DESCRIPTION
This PR should address screensharing freezes. They were caused by the browser's optimization to send only 1 FPS when streaming static content, which caused the Engine to detect the track as inactive and disable it. In this PR a fix is introduced, that changes the activity requirement:
Previously, a track had to send less than 5 packets in one cycle. Now, to be considered inactive, it cannot send a single packet for 3 cycles.

## QA
A typical meeting scenario works best here - in the room where simulcast is enabled, share some static content, eg. Jira, change the card and wait a few seconds. I think the type of screensharing makes a difference here - let's test both sharing the entire screen and a single Chrome tab. Previously, the track would have been disabled after around 5-7 seconds, after the fix it should remain active.

We also need to check if the disabled encoding is correctly detected by the server, which can be observed by disabling a layer that the other peer currently uses. The expected behavior is for another layer to be automatically selected after it is disabled.
Please note that disabling of the encoding is currently broken on videoroom master, due to the FE bug, but a fix is available: https://github.com/membraneframework/membrane_videoroom/pull/86