### PR TITLE
Fix/new track notification

### DIFF
--- a/integration_test/test_videoroom/lib/test_videoroom/room.ex
+++ b/integration_test/test_videoroom/lib/test_videoroom/room.ex
@@ -7,7 +7,7 @@ defmodule TestVideoroom.Room do
   alias Membrane.RTC.Engine.Message
   alias Membrane.RTC.Engine.Endpoint.WebRTC
   alias Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastConfig
-  alias Membrane.WebRTC.Extension.{Mid, Rid, TWCC}
+  alias Membrane.WebRTC.Extension.{Mid, RepairedRid, Rid, TWCC}
   require Logger
 
   def start(opts) do
@@ -107,7 +107,7 @@ defmodule TestVideoroom.Room do
       handshake_opts: handshake_opts,
       log_metadata: [peer_id: peer_id],
       telemetry_label: [room_id: state.room_id, peer_id: peer_id],
-      webrtc_extensions: [Mid, Rid, TWCC],
+      webrtc_extensions: [Mid, Rid, RepairedRid, TWCC],
       simulcast_config: %SimulcastConfig{
         enabled: true,
         initial_target_variant: fn _track -> :medium end
@@ -124,7 +124,10 @@ defmodule TestVideoroom.Room do
   end
 
   @impl true
-  def handle_info(%Message.EndpointMessage{endpoint_id: :broadcast, message: {:media_event, data}}, state) do
+  def handle_info(
+        %Message.EndpointMessage{endpoint_id: :broadcast, message: {:media_event, data}},
+        state
+      ) do
     for {_peer_id, pid} <- state.peer_channels, do: send(pid, {:media_event, data})
     {:noreply, state}
   end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -375,7 +375,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
   @impl true
   def handle_child_notification(
-        {:new_track, track_id, rid, encoding, _depayloading_filter},
+        {:new_track, track_id, rid, ssrc, encoding, _depayloading_filter},
         _from,
         _ctx,
         state
@@ -397,6 +397,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
     Membrane.OpenTelemetry.add_event(@life_span_id, :track_ready, track_id: track_id)
 
     variant = to_track_variant(rid)
+
+    Membrane.Logger.info("New incoming WebRTC track #{track_id} with SSRC #{inspect(ssrc)}")
 
     {[notify_parent: {:track_ready, track_id, variant, encoding}], state}
   end


### PR DESCRIPTION
In e2a841aa1f0df009b88f642d0a5c709d8b565cc0 I've removed too much, this PR fixes that and makes integration tests pass (at least locally)