### PR TITLE
[RTC-228] Don't send new_tracks notification with empty list

### DIFF
--- a/test/membrane_rtc_engine/engine_test.exs
+++ b/test/membrane_rtc_engine/engine_test.exs
@@ -36,6 +36,7 @@ defmodule Membrane.RTC.EngineTest do
 
       assert_receive {:new_peer, %Peer{id: "peer", metadata: "metadata"}}
       assert_receive {:ready, []}
+      refute_receive {:new_tracks, []}
     end
 
     test "is ignored for non-peers", %{rtc_engine: rtc_engine} do
@@ -52,6 +53,7 @@ defmodule Membrane.RTC.EngineTest do
 
       refute_receive {:new_peer, _peer}
       refute_receive {:ready, _peers_in_room}
+      refute_receive {:new_tracks, []}
     end
 
     test "reports other peers", %{rtc_engine: rtc_engine} do


### PR DESCRIPTION
Sending `{:new_tracks, []}` was causing EndpointBin in the webrtc plugin thinking it should send offerData. 

See https://github.com/jellyfish-dev/membrane_webrtc_plugin/blob/master/lib/membrane_webrtc_plugin/endpoint_bin.ex#L689

offerData triggers client SDK to send SDP offer and the whole process of establishing the connection starts.
Because there are no tracks in the SDP, ICE fails (we probably generate wrong SDP) and the whole process is repeated.

The initial idea was not to send offerData when there are no tracks on the server side so I fixed it.