### PR TITLE
[RTC-315] Fix RC on removing tracks

### DIFF
--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Move metrics from the RTC Engine [#306](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/306)
 * Remove unused dependency `membrane_realtimer_plugin` [#300](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/300/)
 * Bump deps [#309](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/309)
+* Fix RC on removing tracks, remove unused `handle_child_pad_removed/4` callback [#308](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/308)
 
 ## 0.1.0
 * Initial release


### PR DESCRIPTION
This description is outdated. Refer to the discussion below for more info.

[OUTDATED] The bug outlined in [RTC-315](https://membraneframework.atlassian.net/browse/RTC-315) had to do with the `remove_child: tee` action -- in some cases, this action would execute too quickly, causing the endpoint pad to get unlinked twice later on. The bug could not be reproduced with this fix: returning the action from the `handle_child_pad_removed` callback of the given endpoint.

The Core team promised to make the error message more descriptive in the future.

[RTC-315]: https://membraneframework.atlassian.net/browse/RTC-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ