### PR TITLE
Fix `endpoint_id` missing in WebRTC endpoint telemetry label. Release WebRTC 0.2.1

### DIFF
--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.1
+* Fix `endpoint_id` missing in WebRTC endpoint telemetry label [#315](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/315/)
+
 ## 0.2.0
 * Move metrics from the RTC Engine [#306](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/306)
 * Remove unused dependency `membrane_realtimer_plugin` [#300](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/300/)

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `membrane_rtc_engine_webrtc` to your list
 ```elixir
 def deps do
   [
-    {:membrane_rtc_engine_webrtc, "~> 0.2.0"}
+    {:membrane_rtc_engine_webrtc, "~> 0.2.1"}
   ]
 end
 ```

--- a/webrtc/lib/webrtc_endpoint.ex
+++ b/webrtc/lib/webrtc_endpoint.ex
@@ -237,6 +237,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
   @impl true
   def handle_init(ctx, opts) do
+    {:endpoint, endpoint_id} = ctx.name
+
+    opts = Map.update!(opts, :telemetry_label, &(&1 ++ [endpoint_id: endpoint_id]))
+
     Membrane.TelemetryMetrics.register(@endpoint_metadata_event, opts.telemetry_label)
     Metrics.register_bandwidth_event(opts.telemetry_label)
 
@@ -279,7 +283,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
         connection_allocator_module: connection_allocator_module
       })
 
-    {:endpoint, endpoint_id} = ctx.name
     {:ok, connection_prober} = state.connection_allocator_module.create()
 
     Membrane.ResourceGuard.register(ctx.resource_guard, fn ->

--- a/webrtc/mix.exs
+++ b/webrtc/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTC.Engine.Endpoint.WebRTC.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @engine_github_url "https://github.com/jellyfish-dev/membrane_rtc_engine"
   @github_url "#{@engine_github_url}/tree/master/webrtc"
   @source_ref "webrtc-v#{@version}"


### PR DESCRIPTION
This was caused by changes from https://github.com/jellyfish-dev/membrane_rtc_engine/pull/306, the `endpoint_id` field used to be appended to the telemetry label when adding the endpoint in the engine