### PR TITLE
RTC-341 Differentiate simulcast and non-simulcast trakcs

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.18.0-dev
 * Bump deps [#318](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/318)
+* Add `get_active_tracks` function in `Endpoint` module [#317](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/317)
 
 ## 0.17.0
 * Cleanup RTC Engine deps. Move metrics to the WebRTC Endpoint [#306](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/306)

--- a/engine/lib/membrane_rtc_engine/endpoint.ex
+++ b/engine/lib/membrane_rtc_engine/endpoint.ex
@@ -55,12 +55,20 @@ defmodule Membrane.RTC.Engine.Endpoint do
     do:
       update_in(endpoint, [:inbound_tracks, track_id, :metadata], fn _old_metadata -> metadata end)
 
-  @spec get_active_track_metadata(endpoint :: t()) :: %{Track.id() => any}
-  def get_active_track_metadata(%__MODULE__{} = endpoint),
+  @spec get_active_tracks(endpoint :: t()) :: %{Track.id() => Track.t()}
+  def get_active_tracks(%__MODULE__{} = endpoint),
     do:
       endpoint.inbound_tracks
       |> Map.values()
       |> Enum.filter(& &1.active?)
+
+  def get_active_tracks(_endpoint), do: %{}
+
+  @spec get_active_track_metadata(endpoint :: t()) :: %{Track.id() => any}
+  def get_active_track_metadata(%__MODULE__{} = endpoint),
+    do:
+      endpoint
+      |> get_active_tracks()
       |> Map.new(&{&1.id, &1.metadata})
 
   def get_active_track_metadata(_endpoint), do: %{}

--- a/engine/lib/membrane_rtc_engine/endpoint.ex
+++ b/engine/lib/membrane_rtc_engine/endpoint.ex
@@ -62,16 +62,12 @@ defmodule Membrane.RTC.Engine.Endpoint do
       |> Map.values()
       |> Enum.filter(& &1.active?)
 
-  def get_active_tracks(_endpoint), do: %{}
-
   @spec get_active_track_metadata(endpoint :: t()) :: %{Track.id() => any}
   def get_active_track_metadata(%__MODULE__{} = endpoint),
     do:
       endpoint
       |> get_active_tracks()
       |> Map.new(&{&1.id, &1.metadata})
-
-  def get_active_track_metadata(_endpoint), do: %{}
 
   @spec update_track_encoding(endpoint :: t(), track_id :: Track.id(), encoding :: atom) :: t()
   def update_track_encoding(endpoint, track_id, value),

--- a/engine/lib/membrane_rtc_engine/endpoint.ex
+++ b/engine/lib/membrane_rtc_engine/endpoint.ex
@@ -55,7 +55,7 @@ defmodule Membrane.RTC.Engine.Endpoint do
     do:
       update_in(endpoint, [:inbound_tracks, track_id, :metadata], fn _old_metadata -> metadata end)
 
-  @spec get_active_tracks(endpoint :: t()) :: %{Track.id() => Track.t()}
+  @spec get_active_tracks(endpoint :: t()) :: [Track.t()]
   def get_active_tracks(%__MODULE__{} = endpoint),
     do:
       endpoint.inbound_tracks

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0-dev
 * Bump deps [#318](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/318)
+* Extend `connected` and `tracksAdded` media events with information about simulcast config. [#317](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/317)
 
 ## 0.2.1
 * Fix `endpoint_id` missing in WebRTC endpoint telemetry label [#315](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/315/)

--- a/webrtc/internal_docs/webrtc_media_events.md
+++ b/webrtc/internal_docs/webrtc_media_events.md
@@ -208,7 +208,7 @@ Messages used by any WebRTC Endpoint plugin
 ### `connected`
 
 * Message sent to the client after connecting to the WebRTC Endpoint. It contains the id of that client's endpoint and a list of information about endpoints in the Engine
-  (id, metadata, a `trackIdToMetadata` and tracks like seen in `tracksAdded` like seen in `tracksAdded`)
+(id, metadata, a `trackIdToMetadata` and tracks like seen in `tracksAdded`)
 
   ```json
   {

--- a/webrtc/internal_docs/webrtc_media_events.md
+++ b/webrtc/internal_docs/webrtc_media_events.md
@@ -51,7 +51,7 @@ Messages used by any WebRTC Endpoint plugin
 #### WebRTC endpoint receives these types of custom `media_event`s from client:
 
 | Name                                            | Description                                                               |
-| ----------------------------------------------- | -----------------------------------------------------------------------   |
+| ----------------------------------------------- | ------------------------------------------------------------------------- |
 | [renegotiateTracks](#renegotiatetracks)         | A request from a client to renegotiate tracks                             |
 | [prioritizeTrack](#prioritizetrack)             | A request to prioritize the track                                         |
 | [unprioritizeTrack](#unprioritizetrack)         | A request to unprioritize the track                                       |
@@ -62,13 +62,13 @@ Messages used by any WebRTC Endpoint plugin
 | [trackVariantBitrates](#trackVariantBitrate)    | Contains updated bitrates for track's variants                            |
 
 #### WebRTC endpoint sends these type of custom messages to client
-| Name                                    | Description                                                       |
-| --------------------------------------- | ----------------------------------------------------------------- |
-| [offerData](#offerdata)                 | Sends data needed by the client to create an offer                |
-| [candidate](#candidate-1)               | Contains an ICE candidate                                         |
-| [sdpAnswer](#sdpanswer)                 | Provides an SDP Answer to the client's offer                      |
-| [encodingSwitched](#encodingswitched)   | An information that a track will be sent with a specific encoding |
-| [vadNotification](#vadnotification)     | An update on Voice Activity Detection                             |
+| Name                                  | Description                                                       |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| [offerData](#offerdata)               | Sends data needed by the client to create an offer                |
+| [candidate](#candidate-1)             | Contains an ICE candidate                                         |
+| [sdpAnswer](#sdpanswer)               | Provides an SDP Answer to the client's offer                      |
+| [encodingSwitched](#encodingswitched) | An information that a track will be sent with a specific encoding |
+| [vadNotification](#vadnotification)   | An update on Voice Activity Detection                             |
 
 
 ## Client -> WebRTC Endpoint
@@ -159,13 +159,25 @@ Messages used by any WebRTC Endpoint plugin
 ### `tracksAdded`
 
 * Informs that one of the clients has added one or more tracks.
-  It contains an id of endpoint associated with that client and a map of all tracks with `track_id`s as keys and `track_metadata` as value.
+  It contains:
+  - an id of endpoint associated with that client, 
+  - a map of all tracks with `track_id`'s as keys and objects with `track_metadata` and simulcast conifg as a value 
+  - (Depracated field use tracks) a map of all tracks with `track_id`s as keys and `track_metadata` as value.
 
   ```json
   {
     endpointId: endpoint_id,
     trackIdToMetadata: {
       track_id: any
+    },
+    tracks: {
+      track_id: {
+        metadata: any
+        simulcastConfig: {
+          enabled: boolean,
+          activeEncodings: string[]
+        }
+      }
     }
   }
   ```
@@ -196,7 +208,7 @@ Messages used by any WebRTC Endpoint plugin
 ### `connected`
 
 * Message sent to the client after connecting to the WebRTC Endpoint. It contains the id of that client's endpoint and a list of information about endpoints in the Engine
-  (id, metadata and a `trackIdToMetadata` like seen in `tracksAdded`)
+  (id, metadata, a `trackIdToMetadata` and tracks like seen in `tracksAdded` like seen in `tracksAdded`)
 
   ```json
   {

--- a/webrtc/lib/webrtc/media_event.ex
+++ b/webrtc/lib/webrtc/media_event.ex
@@ -2,6 +2,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.MediaEvent do
   @moduledoc false
 
   alias Membrane.RTC.Engine.Endpoint
+  alias Membrane.RTC.Engine.Endpoint.WebRTC
   alias Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver
   alias Membrane.RTC.Engine.Track
 

--- a/webrtc/lib/webrtc/media_event.ex
+++ b/webrtc/lib/webrtc/media_event.ex
@@ -372,8 +372,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.MediaEvent do
 
   defp to_type_string(type), do: Module.split(type) |> List.last() |> String.downcase()
 
-  defp map_simulcast_config(track_id_to_simulcast_config),
-    do:
+  defp map_simulcast_config(track_id_to_simulcast_config) do
       Map.new(track_id_to_simulcast_config, fn {track_id, simulcast_config} ->
         simulcast_config = %{
           enabled: simulcast_config.enabled,
@@ -382,4 +381,5 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.MediaEvent do
 
         {track_id, simulcast_config}
       end)
+    end
 end

--- a/webrtc/lib/webrtc/media_event.ex
+++ b/webrtc/lib/webrtc/media_event.ex
@@ -373,13 +373,13 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.MediaEvent do
   defp to_type_string(type), do: Module.split(type) |> List.last() |> String.downcase()
 
   defp map_simulcast_config(track_id_to_simulcast_config) do
-      Map.new(track_id_to_simulcast_config, fn {track_id, simulcast_config} ->
-        simulcast_config = %{
-          enabled: simulcast_config.enabled,
-          activeEncodings: simulcast_config.active_encodings
-        }
+    Map.new(track_id_to_simulcast_config, fn {track_id, simulcast_config} ->
+      simulcast_config = %{
+        enabled: simulcast_config.enabled,
+        activeEncodings: simulcast_config.active_encodings
+      }
 
-        {track_id, simulcast_config}
-      end)
-    end
+      {track_id, simulcast_config}
+    end)
+  end
 end

--- a/webrtc/lib/webrtc_endpoint.ex
+++ b/webrtc/lib/webrtc_endpoint.ex
@@ -94,149 +94,146 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   """
   @type media_event_message_t() :: {:media_event, binary()}
 
-  def_options(
-    rtc_engine: [
-      spec: pid(),
-      description: "Pid of parent Engine"
-    ],
-    direction: [
-      spec: EndpointBin.direction(),
-      default: :sendrecv,
-      description: """
-      Direction of WebRTC Endpoint. Determines whether
-      EndpointBin can send, receive or both send and receive media.
-      For more information refer to t:EndpointBin.direction/0.
-      """
-    ],
-    ice_name: [
-      spec: String.t(),
-      description: "Ice name is used in creating credentials for ice connnection"
-    ],
-    handshake_opts: [
-      type: :list,
-      spec: Keyword.t(),
-      default: [],
-      description: """
-      Keyword list with options for handshake module. For more information please
-      refer to `Membrane.ICE.Bin`
-      """
-    ],
-    filter_codecs: [
-      spec: ({RTPMapping.t(), FMTP.t() | nil} -> boolean()),
-      default: &SDP.filter_encodings(&1),
-      description: "Defines function which will filter SDP m-line by codecs"
-    ],
-    log_metadata: [
-      spec: :list,
-      spec: Keyword.t(),
-      default: [],
-      description: "Logger metadata used for endpoint bin and all its descendants"
-    ],
-    webrtc_extensions: [
-      spec: [module()],
-      default: [],
-      description: """
-      List of WebRTC extensions to use.
+  def_options rtc_engine: [
+                spec: pid(),
+                description: "Pid of parent Engine"
+              ],
+              direction: [
+                spec: EndpointBin.direction(),
+                default: :sendrecv,
+                description: """
+                Direction of WebRTC Endpoint. Determines whether
+                EndpointBin can send, receive or both send and receive media.
+                For more information refer to t:EndpointBin.direction/0.
+                """
+              ],
+              ice_name: [
+                spec: String.t(),
+                description: "Ice name is used in creating credentials for ice connnection"
+              ],
+              handshake_opts: [
+                type: :list,
+                spec: Keyword.t(),
+                default: [],
+                description: """
+                Keyword list with options for handshake module. For more information please
+                refer to `Membrane.ICE.Bin`
+                """
+              ],
+              filter_codecs: [
+                spec: ({RTPMapping.t(), FMTP.t() | nil} -> boolean()),
+                default: &SDP.filter_encodings(&1),
+                description: "Defines function which will filter SDP m-line by codecs"
+              ],
+              log_metadata: [
+                spec: :list,
+                spec: Keyword.t(),
+                default: [],
+                description: "Logger metadata used for endpoint bin and all its descendants"
+              ],
+              webrtc_extensions: [
+                spec: [module()],
+                default: [],
+                description: """
+                List of WebRTC extensions to use.
 
-      Each module has to implement `Membrane.WebRTC.Extension.t()`.
-      See `membrane_webrtc_plugin` documentation for a list of possible extensions.
-      """
-    ],
-    extensions: [
-      spec: %{
-        (encoding_name :: atom() | :any) => [Membrane.RTP.SessionBin.extension_t()]
-      },
-      default: %{},
-      description: """
-      A map pointing from encoding names to lists of extensions that should be used for given encodings.
-      Encoding "`:any`" indicates that extensions should be applied regardless of encoding.
+                Each module has to implement `Membrane.WebRTC.Extension.t()`.
+                See `membrane_webrtc_plugin` documentation for a list of possible extensions.
+                """
+              ],
+              extensions: [
+                spec: %{
+                  (encoding_name :: atom() | :any) => [Membrane.RTP.SessionBin.extension_t()]
+                },
+                default: %{},
+                description: """
+                A map pointing from encoding names to lists of extensions that should be used for given encodings.
+                Encoding "`:any`" indicates that extensions should be applied regardless of encoding.
 
-      A sample usage would be to add silence discarder to OPUS tracks when VAD extension is enabled.
-      It can greatly reduce CPU usage in rooms when there are a lot of people but only a few of
-      them are actively speaking.
-      """
-    ],
-    integrated_turn_domain: [
-      spec: binary() | nil,
-      default: nil,
-      description: "Domain address of integrated TURN Servers. Required for TLS TURN"
-    ],
-    integrated_turn_options: [
-      spec: Membrane.ICE.Endpoint.integrated_turn_options_t(),
-      default: []
-    ],
-    owner: [
-      spec: pid(),
-      description: """
-      Pid of parent all notifications will be send to.
+                A sample usage would be to add silence discarder to OPUS tracks when VAD extension is enabled.
+                It can greatly reduce CPU usage in rooms when there are a lot of people but only a few of
+                them are actively speaking.
+                """
+              ],
+              integrated_turn_domain: [
+                spec: binary() | nil,
+                default: nil,
+                description: "Domain address of integrated TURN Servers. Required for TLS TURN"
+              ],
+              integrated_turn_options: [
+                spec: Membrane.ICE.Endpoint.integrated_turn_options_t(),
+                default: []
+              ],
+              owner: [
+                spec: pid(),
+                description: """
+                Pid of parent all notifications will be send to.
 
-      To see possible notifications please refer to module docs.
-      """
-    ],
-    trace_context: [
-      spec: :list,
-      default: [],
-      description: "Trace context for otel propagation"
-    ],
-    parent_span: [
-      spec: :opentelemetry.span_ctx() | nil,
-      default: nil,
-      description: "Parent span of #{@life_span_id}"
-    ],
-    video_tracks_limit: [
-      spec: integer() | nil,
-      default: nil,
-      description: """
-      Maximal number of video tracks that will be sent to the the browser at the same time.
+                To see possible notifications please refer to module docs.
+                """
+              ],
+              trace_context: [
+                spec: :list,
+                default: [],
+                description: "Trace context for otel propagation"
+              ],
+              parent_span: [
+                spec: :opentelemetry.span_ctx() | nil,
+                default: nil,
+                description: "Parent span of #{@life_span_id}"
+              ],
+              video_tracks_limit: [
+                spec: integer() | nil,
+                default: nil,
+                description: """
+                Maximal number of video tracks that will be sent to the the browser at the same time.
 
-      This variable indicates how many video tracks should be sent to the browser at the same time.
-      If `nil` all video tracks this `#{inspect(__MODULE__)}` receives will be sent.
-      """
-    ],
-    rtcp_receiver_report_interval: [
-      spec: Membrane.Time.t() | nil,
-      default: nil,
-      description:
-        "Receiver reports's generation interval, set to nil to avoid reports generation"
-    ],
-    rtcp_sender_report_interval: [
-      spec: Membrane.Time.t() | nil,
-      default: nil,
-      description: "Sender reports's generation interval, set to nil to avoid reports generation"
-    ],
-    simulcast_config: [
-      spec: SimulcastConfig.t(),
-      default: %SimulcastConfig{},
-      description: "Simulcast configuration"
-    ],
-    metadata: [
-      spec: any(),
-      default: nil,
-      description: "Endpoint metadata"
-    ],
-    telemetry_label: [
-      spec: Membrane.TelemetryMetrics.label(),
-      default: [],
-      description: "Label passed to Membrane.TelemetryMetrics functions"
-    ],
-    toilet_capacity: [
-      spec: pos_integer(),
-      default: 200,
-      description: "TrackReceiver toilet capacity"
-    ]
-  )
+                This variable indicates how many video tracks should be sent to the browser at the same time.
+                If `nil` all video tracks this `#{inspect(__MODULE__)}` receives will be sent.
+                """
+              ],
+              rtcp_receiver_report_interval: [
+                spec: Membrane.Time.t() | nil,
+                default: nil,
+                description:
+                  "Receiver reports's generation interval, set to nil to avoid reports generation"
+              ],
+              rtcp_sender_report_interval: [
+                spec: Membrane.Time.t() | nil,
+                default: nil,
+                description:
+                  "Sender reports's generation interval, set to nil to avoid reports generation"
+              ],
+              simulcast_config: [
+                spec: SimulcastConfig.t(),
+                default: %SimulcastConfig{},
+                description: "Simulcast configuration"
+              ],
+              metadata: [
+                spec: any(),
+                default: nil,
+                description: "Endpoint metadata"
+              ],
+              telemetry_label: [
+                spec: Membrane.TelemetryMetrics.label(),
+                default: [],
+                description: "Label passed to Membrane.TelemetryMetrics functions"
+              ],
+              toilet_capacity: [
+                spec: pos_integer(),
+                default: 200,
+                description: "TrackReceiver toilet capacity"
+              ]
 
-  def_input_pad(:input,
+  def_input_pad :input,
     demand_unit: :buffers,
     accepted_format: _any,
     availability: :on_request
-  )
 
-  def_output_pad(:output,
+  def_output_pad :output,
     demand_unit: :buffers,
     accepted_format: _any,
     availability: :on_request
-  )
 
   @impl true
   def handle_init(ctx, opts) do
@@ -618,11 +615,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
       |> Enum.map(fn {origin, tracks} ->
         track_id_to_metadata = Map.new(tracks, &{&1.id, &1.metadata})
 
-        track_id_to_simulcast_config =
-          Map.new(tracks, fn track ->
-            encodings = Enum.map(track.variants, &to_rid/1)
-            {track.id, %{enabled: encodings == [:high], active_encodings: encodings}}
-          end)
+        track_id_to_simulcast_config = tracks_to_simulcast_config(tracks)
 
         media_event =
           origin
@@ -969,7 +962,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
     do:
       Map.new(tracks, fn track ->
         encodings = Enum.map(track.variants, &to_rid/1)
-        {track.id, %{enabled: encodings == [:high], active_encodings: encodings}}
+        {track.id, %{enabled: encodings !== [:high], active_encodings: encodings}}
       end)
 
   defp to_track_variant(rid) when rid in ["h", nil], do: :high

--- a/webrtc/lib/webrtc_endpoint.ex
+++ b/webrtc/lib/webrtc_endpoint.ex
@@ -73,7 +73,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   }
 
   alias Membrane.RTC.Engine.Notifications.TrackNotification
-  alias Membrane.RTC.Engine.Track
+  alias Membrane.RTC.Engine.{Endpoint, Track}
   alias Membrane.WebRTC
   alias Membrane.WebRTC.{EndpointBin, SDP}
 
@@ -94,146 +94,149 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   """
   @type media_event_message_t() :: {:media_event, binary()}
 
-  def_options rtc_engine: [
-                spec: pid(),
-                description: "Pid of parent Engine"
-              ],
-              direction: [
-                spec: EndpointBin.direction(),
-                default: :sendrecv,
-                description: """
-                Direction of WebRTC Endpoint. Determines whether
-                EndpointBin can send, receive or both send and receive media.
-                For more information refer to t:EndpointBin.direction/0.
-                """
-              ],
-              ice_name: [
-                spec: String.t(),
-                description: "Ice name is used in creating credentials for ice connnection"
-              ],
-              handshake_opts: [
-                type: :list,
-                spec: Keyword.t(),
-                default: [],
-                description: """
-                Keyword list with options for handshake module. For more information please
-                refer to `Membrane.ICE.Bin`
-                """
-              ],
-              filter_codecs: [
-                spec: ({RTPMapping.t(), FMTP.t() | nil} -> boolean()),
-                default: &SDP.filter_encodings(&1),
-                description: "Defines function which will filter SDP m-line by codecs"
-              ],
-              log_metadata: [
-                spec: :list,
-                spec: Keyword.t(),
-                default: [],
-                description: "Logger metadata used for endpoint bin and all its descendants"
-              ],
-              webrtc_extensions: [
-                spec: [module()],
-                default: [],
-                description: """
-                List of WebRTC extensions to use.
+  def_options(
+    rtc_engine: [
+      spec: pid(),
+      description: "Pid of parent Engine"
+    ],
+    direction: [
+      spec: EndpointBin.direction(),
+      default: :sendrecv,
+      description: """
+      Direction of WebRTC Endpoint. Determines whether
+      EndpointBin can send, receive or both send and receive media.
+      For more information refer to t:EndpointBin.direction/0.
+      """
+    ],
+    ice_name: [
+      spec: String.t(),
+      description: "Ice name is used in creating credentials for ice connnection"
+    ],
+    handshake_opts: [
+      type: :list,
+      spec: Keyword.t(),
+      default: [],
+      description: """
+      Keyword list with options for handshake module. For more information please
+      refer to `Membrane.ICE.Bin`
+      """
+    ],
+    filter_codecs: [
+      spec: ({RTPMapping.t(), FMTP.t() | nil} -> boolean()),
+      default: &SDP.filter_encodings(&1),
+      description: "Defines function which will filter SDP m-line by codecs"
+    ],
+    log_metadata: [
+      spec: :list,
+      spec: Keyword.t(),
+      default: [],
+      description: "Logger metadata used for endpoint bin and all its descendants"
+    ],
+    webrtc_extensions: [
+      spec: [module()],
+      default: [],
+      description: """
+      List of WebRTC extensions to use.
 
-                Each module has to implement `Membrane.WebRTC.Extension.t()`.
-                See `membrane_webrtc_plugin` documentation for a list of possible extensions.
-                """
-              ],
-              extensions: [
-                spec: %{
-                  (encoding_name :: atom() | :any) => [Membrane.RTP.SessionBin.extension_t()]
-                },
-                default: %{},
-                description: """
-                A map pointing from encoding names to lists of extensions that should be used for given encodings.
-                Encoding "`:any`" indicates that extensions should be applied regardless of encoding.
+      Each module has to implement `Membrane.WebRTC.Extension.t()`.
+      See `membrane_webrtc_plugin` documentation for a list of possible extensions.
+      """
+    ],
+    extensions: [
+      spec: %{
+        (encoding_name :: atom() | :any) => [Membrane.RTP.SessionBin.extension_t()]
+      },
+      default: %{},
+      description: """
+      A map pointing from encoding names to lists of extensions that should be used for given encodings.
+      Encoding "`:any`" indicates that extensions should be applied regardless of encoding.
 
-                A sample usage would be to add silence discarder to OPUS tracks when VAD extension is enabled.
-                It can greatly reduce CPU usage in rooms when there are a lot of people but only a few of
-                them are actively speaking.
-                """
-              ],
-              integrated_turn_domain: [
-                spec: binary() | nil,
-                default: nil,
-                description: "Domain address of integrated TURN Servers. Required for TLS TURN"
-              ],
-              integrated_turn_options: [
-                spec: Membrane.ICE.Endpoint.integrated_turn_options_t(),
-                default: []
-              ],
-              owner: [
-                spec: pid(),
-                description: """
-                Pid of parent all notifications will be send to.
+      A sample usage would be to add silence discarder to OPUS tracks when VAD extension is enabled.
+      It can greatly reduce CPU usage in rooms when there are a lot of people but only a few of
+      them are actively speaking.
+      """
+    ],
+    integrated_turn_domain: [
+      spec: binary() | nil,
+      default: nil,
+      description: "Domain address of integrated TURN Servers. Required for TLS TURN"
+    ],
+    integrated_turn_options: [
+      spec: Membrane.ICE.Endpoint.integrated_turn_options_t(),
+      default: []
+    ],
+    owner: [
+      spec: pid(),
+      description: """
+      Pid of parent all notifications will be send to.
 
-                To see possible notifications please refer to module docs.
-                """
-              ],
-              trace_context: [
-                spec: :list,
-                default: [],
-                description: "Trace context for otel propagation"
-              ],
-              parent_span: [
-                spec: :opentelemetry.span_ctx() | nil,
-                default: nil,
-                description: "Parent span of #{@life_span_id}"
-              ],
-              video_tracks_limit: [
-                spec: integer() | nil,
-                default: nil,
-                description: """
-                Maximal number of video tracks that will be sent to the the browser at the same time.
+      To see possible notifications please refer to module docs.
+      """
+    ],
+    trace_context: [
+      spec: :list,
+      default: [],
+      description: "Trace context for otel propagation"
+    ],
+    parent_span: [
+      spec: :opentelemetry.span_ctx() | nil,
+      default: nil,
+      description: "Parent span of #{@life_span_id}"
+    ],
+    video_tracks_limit: [
+      spec: integer() | nil,
+      default: nil,
+      description: """
+      Maximal number of video tracks that will be sent to the the browser at the same time.
 
-                This variable indicates how many video tracks should be sent to the browser at the same time.
-                If `nil` all video tracks this `#{inspect(__MODULE__)}` receives will be sent.
-                """
-              ],
-              rtcp_receiver_report_interval: [
-                spec: Membrane.Time.t() | nil,
-                default: nil,
-                description:
-                  "Receiver reports's generation interval, set to nil to avoid reports generation"
-              ],
-              rtcp_sender_report_interval: [
-                spec: Membrane.Time.t() | nil,
-                default: nil,
-                description:
-                  "Sender reports's generation interval, set to nil to avoid reports generation"
-              ],
-              simulcast_config: [
-                spec: SimulcastConfig.t(),
-                default: %SimulcastConfig{},
-                description: "Simulcast configuration"
-              ],
-              metadata: [
-                spec: any(),
-                default: nil,
-                description: "Endpoint metadata"
-              ],
-              telemetry_label: [
-                spec: Membrane.TelemetryMetrics.label(),
-                default: [],
-                description: "Label passed to Membrane.TelemetryMetrics functions"
-              ],
-              toilet_capacity: [
-                spec: pos_integer(),
-                default: 200,
-                description: "TrackReceiver toilet capacity"
-              ]
+      This variable indicates how many video tracks should be sent to the browser at the same time.
+      If `nil` all video tracks this `#{inspect(__MODULE__)}` receives will be sent.
+      """
+    ],
+    rtcp_receiver_report_interval: [
+      spec: Membrane.Time.t() | nil,
+      default: nil,
+      description:
+        "Receiver reports's generation interval, set to nil to avoid reports generation"
+    ],
+    rtcp_sender_report_interval: [
+      spec: Membrane.Time.t() | nil,
+      default: nil,
+      description: "Sender reports's generation interval, set to nil to avoid reports generation"
+    ],
+    simulcast_config: [
+      spec: SimulcastConfig.t(),
+      default: %SimulcastConfig{},
+      description: "Simulcast configuration"
+    ],
+    metadata: [
+      spec: any(),
+      default: nil,
+      description: "Endpoint metadata"
+    ],
+    telemetry_label: [
+      spec: Membrane.TelemetryMetrics.label(),
+      default: [],
+      description: "Label passed to Membrane.TelemetryMetrics functions"
+    ],
+    toilet_capacity: [
+      spec: pos_integer(),
+      default: 200,
+      description: "TrackReceiver toilet capacity"
+    ]
+  )
 
-  def_input_pad :input,
+  def_input_pad(:input,
     demand_unit: :buffers,
     accepted_format: _any,
     availability: :on_request
+  )
 
-  def_output_pad :output,
+  def_output_pad(:output,
     demand_unit: :buffers,
     accepted_format: _any,
     availability: :on_request
+  )
 
   @impl true
   def handle_init(ctx, opts) do
@@ -529,7 +532,20 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
     # FIXME: I don't think we actually need information about tracks in this media event
     {:endpoint, endpoint_id} = ctx.name
-    event = MediaEvent.connected(endpoint_id, other_endpoints) |> MediaEvent.encode()
+
+    endpoint_id_to_simulcast_config_map =
+      other_endpoints
+      |> Map.new(fn endpoint ->
+        track_id_to_simulcast_config =
+          endpoint |> Endpoint.get_active_tracks() |> tracks_to_simulcast_config()
+
+        {endpoint.id, track_id_to_simulcast_config}
+      end)
+
+    event =
+      endpoint_id
+      |> MediaEvent.connected(other_endpoints, endpoint_id_to_simulcast_config_map)
+      |> MediaEvent.encode()
 
     {[notify_parent: {:forward_to_parent, {:media_event, event}}], state}
   end
@@ -602,9 +618,15 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
       |> Enum.map(fn {origin, tracks} ->
         track_id_to_metadata = Map.new(tracks, &{&1.id, &1.metadata})
 
+        track_id_to_simulcast_config =
+          Map.new(tracks, fn track ->
+            encodings = Enum.map(track.variants, &to_rid/1)
+            {track.id, %{enabled: encodings == [:high], active_encodings: encodings}}
+          end)
+
         media_event =
           origin
-          |> MediaEvent.tracks_added(track_id_to_metadata)
+          |> MediaEvent.tracks_added(track_id_to_metadata, track_id_to_simulcast_config)
           |> MediaEvent.encode()
 
         {:notify_parent, {:forward_to_parent, {:media_event, media_event}}}
@@ -942,6 +964,13 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
       {key, value} -> {key, value}
     end)
   end
+
+  defp tracks_to_simulcast_config(tracks),
+    do:
+      Map.new(tracks, fn track ->
+        encodings = Enum.map(track.variants, &to_rid/1)
+        {track.id, %{enabled: encodings == [:high], active_encodings: encodings}}
+      end)
 
   defp to_track_variant(rid) when rid in ["h", nil], do: :high
   defp to_track_variant("m"), do: :medium

--- a/webrtc/lib/webrtc_endpoint.ex
+++ b/webrtc/lib/webrtc_endpoint.ex
@@ -73,7 +73,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   }
 
   alias Membrane.RTC.Engine.Notifications.TrackNotification
-  alias Membrane.RTC.Engine.{Endpoint, Track}
+  alias Membrane.RTC.Engine.{Track}
   alias Membrane.WebRTC
   alias Membrane.WebRTC.{EndpointBin, SDP}
 
@@ -772,7 +772,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
     {[], state}
   end
 
-  @spec to_rid(:high | :medium | :low) :: "h" | "m" | "l"
+  @spec to_rid(:high | :medium | :low) :: String.t()
   def to_rid(:high), do: "h"
   def to_rid(:medium), do: "m"
   def to_rid(:low), do: "l"


### PR DESCRIPTION
The main objective of this PR is to send information about tracks SimulcastConfig to WebRTC clients so they can identify which tracks are simulcast and which are not. 
It is related to [this PR](https://github.com/jellyfish-dev/membrane-webrtc-js/pull/34)