### PR TITLE
Rename functions to be compliant with elixir style guide

### DIFF
--- a/engine/.credo.exs
+++ b/engine/.credo.exs
@@ -102,7 +102,7 @@
         {Credo.Check.Readability.ModuleNames, []},
         {Credo.Check.Readability.ParenthesesInCondition, []},
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: true},
-        {Credo.Check.Readability.PredicateFunctionNames, [exit_status: 0]},
+        {Credo.Check.Readability.PredicateFunctionNames, []},
         {Credo.Check.Readability.PreferImplicitTry, []},
         {Credo.Check.Readability.RedundantBlankLines, []},
         {Credo.Check.Readability.Semicolons, []},

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 0.20.0-dev
-
+* Rename the function `is_simulcast` to `simulcast?`` in order to be compliant with elixir style guide. []
+  
 ## 0.19.0
 * Discard messages from endpoints that are not marked as ready [#339](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/339)
 * Extend Engine.terminate API [#337](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/337)

--- a/engine/lib/membrane_rtc_engine/track.ex
+++ b/engine/lib/membrane_rtc_engine/track.ex
@@ -201,6 +201,6 @@ defmodule Membrane.RTC.Engine.Track do
   @doc """
   Checks whether track is a simulcast one or not.
   """
-  @spec is_simulcast?(t()) :: boolean()
-  def is_simulcast?(%__MODULE__{} = track), do: track.variants != [:high]
+  @spec simulcast?(t()) :: boolean()
+  def simulcast?(%__MODULE__{} = track), do: track.variants != [:high]
 end

--- a/webrtc/.credo.exs
+++ b/webrtc/.credo.exs
@@ -102,7 +102,7 @@
         {Credo.Check.Readability.ModuleNames, []},
         {Credo.Check.Readability.ParenthesesInCondition, []},
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: true},
-        {Credo.Check.Readability.PredicateFunctionNames, [exit_status: 0]},
+        {Credo.Check.Readability.PredicateFunctionNames, []},
         {Credo.Check.Readability.PreferImplicitTry, []},
         {Credo.Check.Readability.RedundantBlankLines, []},
         {Credo.Check.Readability.Semicolons, []},

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.6.0-dev
+* Rename the function `is_keyframe` to `keyframe?` and `is_deficient?` to `deficient?` in order to be compliant with elixir style guide. []
 
 ## 0.5.0
 * Update to Membrane Core 1.0 [#331](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/331)

--- a/webrtc/lib/webrtc/rtp_connection_allocator.ex
+++ b/webrtc/lib/webrtc/rtp_connection_allocator.ex
@@ -344,12 +344,12 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
       state.prober_status in [:allowed_overuse, :disallowed_overuse] ->
         state
 
-      not is_deficient?(state) and state.prober_status != :maintain_allocation ->
+      not deficient?(state) and state.prober_status != :maintain_allocation ->
         Logger.debug("Switching prober state to maintain estimation")
 
         Map.put(state, :prober_status, :maintain_allocation)
 
-      is_deficient?(state) and state.prober_status != :increase_estimation ->
+      deficient?(state) and state.prober_status != :increase_estimation ->
         Logger.debug("Switching prober state to increase estimation")
 
         Map.put(state, :prober_status, :increase_estimation)
@@ -378,7 +378,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
 
       state.prober_status in [:allowed_overuse, :disallowed_overuse] and
           state.estimated_sender_rate <= state.available_bandwidth ->
-        new_status = if is_deficient?(state), do: :increase_estimation, else: :maintain_allocation
+        new_status = if deficient?(state), do: :increase_estimation, else: :maintain_allocation
 
         Logger.debug(
           "Switching prober state to #{new_status} after being in the state of #{state.prober_status}"
@@ -400,7 +400,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
     |> maybe_change_probing_status()
   end
 
-  defp is_deficient?(state),
+  defp deficient?(state),
     do:
       state.track_receivers
       |> Map.values()

--- a/webrtc/test/webrtc/track_sender_test.exs
+++ b/webrtc/test/webrtc/track_sender_test.exs
@@ -38,7 +38,7 @@ defmodule Membrane.RTC.Engine.WebRTC.TrackSenderTest do
         {Track.new(:audio, @stream_id, @track_origin, :OPUS, 48_000, nil, id: @track_id), true}
       ]
       |> Enum.each(fn {track, expected_is_keyframe_value} ->
-        test_is_keyframe(track, expected_is_keyframe_value)
+        test_keyframe?(track, expected_is_keyframe_value)
       end)
     end
 
@@ -187,7 +187,7 @@ defmodule Membrane.RTC.Engine.WebRTC.TrackSenderTest do
     Pipeline.terminate(pipeline)
   end
 
-  defp test_is_keyframe(%Track{type: :audio} = track, expected_is_keyframe_value) do
+  defp test_keyframe?(%Track{type: :audio} = track, expected_is_keyframe_value) do
     test_payload = <<1, 2, 3, 4, 5>>
 
     pipeline = build_audio_pipeline(track, [test_payload])
@@ -200,7 +200,7 @@ defmodule Membrane.RTC.Engine.WebRTC.TrackSenderTest do
     Pipeline.terminate(pipeline)
   end
 
-  defp test_is_keyframe(track, expected_is_keyframe_value) do
+  defp test_keyframe?(track, expected_is_keyframe_value) do
     test_payload = <<1, 2, 3, 4, 5>>
 
     pipeline = build_video_pipeline(track, {nil, &Utils.generator/2})


### PR DESCRIPTION
I'm not sure if we want to rename those functions to be compliant with the newest credo version. There are a lot of variables in code named in `is_<name>` manner. Also functions from other repositories for example RTP have functions like `is_keyframe`.
