### PR TITLE
Extend recording report created by RecordingEndpoint

### DIFF
--- a/integration_test/test/recording_endpoint_test.exs
+++ b/integration_test/test/recording_endpoint_test.exs
@@ -94,7 +94,7 @@ defmodule Membrane.RTC.RecordingEndpointTest do
     video_file_endpoint_id = "video-file-endpoint"
 
     audio_file_path = Path.join(@fixtures_dir, "audio.aac")
-    video_file_path = Path.join(@fixtures_dir, "recorded_video.h264")
+    video_file_path = Path.join(@fixtures_dir, "video_baseline.h264")
     report_file_path = Path.join(output_dir, @report_filename)
 
     deserialized_audio_path = Path.join(output_dir, "deserialized_audio.aac")
@@ -149,6 +149,81 @@ defmodule Membrane.RTC.RecordingEndpointTest do
 
     assert deserialized_audio_path |> File.read!() |> byte_size() > 0
     assert deserialized_video_path |> File.read!() |> byte_size() > 0
+  end
+
+  @tag :tmp_dir
+  test "creates correct recording, multiple videos and audios", %{
+    rtc_engine: rtc_engine,
+    tmp_dir: output_dir
+  } do
+    recording_endpoint_id = "recording-endpoint"
+    audio_file_endpoint_id1 = "audio-file-endpoint1"
+    video_file_endpoint_id1 = "video-file-endpoint1"
+    audio_file_endpoint_id2 = "audio-file-endpoint2"
+    video_file_endpoint_id2 = "video-file-endpoint2"
+
+    audio_file_path = Path.join(@fixtures_dir, "audio.aac")
+    video_file_path = Path.join(@fixtures_dir, "video_baseline.h264")
+    report_file_path = Path.join(output_dir, @report_filename)
+
+    deserialized_audio_path = Path.join(output_dir, "deserialized_audio.aac")
+    deserialized_video_path = Path.join(output_dir, "deserialized_video.h264")
+
+    recording_endpoint = create_recording_endpoint(rtc_engine, output_dir)
+    audio_file_endpoint = create_audio_file_endpoint(rtc_engine, audio_file_path)
+    video_file_endpoint = create_video_file_endpoint(rtc_engine, video_file_path)
+
+    :ok = Engine.add_endpoint(rtc_engine, recording_endpoint, id: recording_endpoint_id)
+    :ok = Engine.add_endpoint(rtc_engine, video_file_endpoint, id: video_file_endpoint_id1)
+    :ok = Engine.add_endpoint(rtc_engine, audio_file_endpoint, id: audio_file_endpoint_id1)
+
+    assert_receive %TrackAdded{endpoint_id: ^video_file_endpoint_id1}, @tracks_added_delay
+    assert_receive %TrackAdded{endpoint_id: ^audio_file_endpoint_id1}, @tracks_added_delay
+
+    :ok = Engine.add_endpoint(rtc_engine, video_file_endpoint, id: video_file_endpoint_id2)
+    :ok = Engine.add_endpoint(rtc_engine, audio_file_endpoint, id: audio_file_endpoint_id2)
+
+    assert_receive %TrackRemoved{endpoint_id: ^video_file_endpoint_id1}, @tracks_removed_delay
+    assert_receive %TrackRemoved{endpoint_id: ^audio_file_endpoint_id1}, @tracks_removed_delay
+
+    assert_receive %TrackAdded{endpoint_id: ^video_file_endpoint_id2}, @tracks_added_delay
+    assert_receive %TrackAdded{endpoint_id: ^audio_file_endpoint_id2}, @tracks_added_delay
+
+    assert_receive %TrackRemoved{endpoint_id: ^video_file_endpoint_id2}, @tracks_removed_delay
+    assert_receive %TrackRemoved{endpoint_id: ^audio_file_endpoint_id2}, @tracks_removed_delay
+
+    filenames = File.ls!(output_dir)
+    audio_file = Enum.find(filenames, fn filename -> String.starts_with?(filename, "audio") end)
+    video_file = Enum.find(filenames, fn filename -> String.starts_with?(filename, "video") end)
+
+    audio_deserializer =
+      create_audio_deserializer(%{
+        source: Path.join(output_dir, audio_file),
+        output: deserialized_audio_path,
+        owner: self()
+      })
+
+    video_deserializer =
+      create_video_deserializer(%{
+        source: Path.join(output_dir, video_file),
+        output: deserialized_video_path,
+        owner: self()
+      })
+
+    audio_pipeline = Membrane.Testing.Pipeline.start_link_supervised!(spec: audio_deserializer)
+    video_pipeline = Membrane.Testing.Pipeline.start_link_supervised!(spec: video_deserializer)
+
+    assert_end_of_stream(audio_pipeline, :sink)
+    assert_end_of_stream(video_pipeline, :sink)
+
+    assert deserialized_audio_path |> File.read!() |> byte_size() > 0
+    assert deserialized_video_path |> File.read!() |> byte_size() > 0
+
+    Engine.remove_endpoint(rtc_engine, recording_endpoint_id)
+    assert_receive %EndpointRemoved{endpoint_id: ^recording_endpoint_id}
+
+    await_report(report_file_path)
+    validate_report(report_file_path)
   end
 
   setup :verify_on_exit!

--- a/integration_test/test/recording_endpoint_test.exs
+++ b/integration_test/test/recording_endpoint_test.exs
@@ -201,11 +201,9 @@ defmodule Membrane.RTC.RecordingEndpointTest do
     validate_report(report_file_path)
     assert %{"tracks" => tracks} = report_file_path |> File.read!() |> Jason.decode!()
 
-    audio_tracks =
-      Enum.filter(tracks, fn {_filename, track} -> track["type"] == "audio" end)
+    audio_tracks = Enum.filter(tracks, fn {_filename, track} -> track["type"] == "audio" end)
 
-    video_tracks =
-      Enum.filter(tracks, fn {_filename, track} -> track["type"] == "video" end)
+    video_tracks = Enum.filter(tracks, fn {_filename, track} -> track["type"] == "video" end)
 
     audio_pipelines =
       audio_tracks

--- a/recording/CHANGELOG.md
+++ b/recording/CHANGELOG.md
@@ -6,3 +6,4 @@
 * Add working AWS storage [#369](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/369)
 * Refactor storage API [#375](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/375)
 * Update deps [#374](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/374)
+* Extend report created by RecordingEndpoint [#376](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/376)

--- a/recording/lib/edge_timestamp_saver.ex
+++ b/recording/lib/edge_timestamp_saver.ex
@@ -1,4 +1,4 @@
-defmodule Membrane.RTC.Engine.Endpoint.Recording.LastBufferTimestamp do
+defmodule Membrane.RTC.Engine.Endpoint.Recording.EdgeTimestampSaver do
   @moduledoc false
 
   use Membrane.Filter

--- a/recording/lib/last_buffer_timestamp.ex
+++ b/recording/lib/last_buffer_timestamp.ex
@@ -32,7 +32,11 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.LastBufferTimestamp do
 
   @impl true
   def handle_buffer(_pad, %Buffer{} = buffer, ctx, %{first_buffer_timestamp: nil} = state) do
-    Recording.Reporter.start_track(state.reporter, track_id(ctx), buffer.metadata.rtp.timestamp)
+    Recording.Reporter.start_timestamp(
+      state.reporter,
+      track_id(ctx),
+      buffer.metadata.rtp.timestamp
+    )
 
     {[buffer: {:output, buffer}],
      %{state | first_buffer_timestamp: buffer.metadata.rtp.timestamp}}
@@ -44,7 +48,11 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.LastBufferTimestamp do
 
     if counter == 0,
       do:
-        Recording.Reporter.end_track(state.reporter, track_id(ctx), buffer.metadata.rtp.timestamp)
+        Recording.Reporter.end_timestamp(
+          state.reporter,
+          track_id(ctx),
+          buffer.metadata.rtp.timestamp
+        )
 
     {[buffer: {:output, buffer}],
      %{state | counter: counter, last_buffer_timestamp: buffer.metadata.rtp.timestamp}}
@@ -52,7 +60,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.LastBufferTimestamp do
 
   @impl true
   def handle_end_of_stream(_pad, ctx, state) do
-    Recording.Reporter.end_track(state.reporter, track_id(ctx), state.last_buffer_timestamp)
+    Recording.Reporter.end_timestamp(state.reporter, track_id(ctx), state.last_buffer_timestamp)
     {[end_of_stream: :output], state}
   end
 

--- a/recording/lib/last_buffer_timestamp.ex
+++ b/recording/lib/last_buffer_timestamp.ex
@@ -1,0 +1,52 @@
+defmodule Membrane.RTC.Engine.Endpoint.Recording.LastBufferTimestamp do
+  @moduledoc false
+
+  use Membrane.Filter
+
+  alias Membrane.Buffer
+  alias Membrane.RTC.Engine.Endpoint.Recording
+
+  def_input_pad :input, accepted_format: _accepted_format
+
+  def_output_pad :output, accepted_format: _accepted_format
+
+  def_options reporter: [
+                spec: pid(),
+                description: """
+                Pid of the recording reporter
+                """
+              ]
+
+  @impl true
+  def handle_init(_ctx, options) do
+    {[],
+     %{
+       first_buffer_timestamp: nil,
+       counter: 0,
+       reporter: options.reporter
+     }}
+  end
+
+  @impl true
+  def handle_buffer(_pad, %Buffer{} = buffer, ctx, %{first_buffer_timestamp: nil} = state) do
+    Recording.Reporter.start_track(state.reporter, track_id(ctx), buffer.metadata.rtp.timestamp)
+
+    {[buffer: {:output, buffer}],
+     %{state | first_buffer_timestamp: buffer.metadata.rtp.timestamp}}
+  end
+
+  @impl true
+  def handle_buffer(_pad, %Buffer{} = buffer, ctx, state) do
+    counter =
+      if state.counter + 1 == 200 do
+        Recording.Reporter.end_track(state.reporter, track_id(ctx), buffer.metadata.rtp.timestamp)
+        0
+      else
+        state.counter + 1
+      end
+
+    {[buffer: {:output, buffer}], %{state | counter: counter}}
+  end
+
+  defp track_id(%{name: {:last_buffer_timestamp, track_id}}), do: track_id
+end

--- a/recording/lib/recording_endpoint.ex
+++ b/recording/lib/recording_endpoint.ex
@@ -8,7 +8,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording do
   require Membrane.Logger
 
   alias Membrane.RTC.Engine
-  alias Membrane.RTC.Engine.Endpoint.Recording.{LastBufferTimestamp, Reporter}
+  alias Membrane.RTC.Engine.Endpoint.Recording.{EdgeTimestampSaver, Reporter}
   alias Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver
 
   @type storage_opts :: any()
@@ -155,7 +155,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording do
             track: track,
             initial_target_variant: :high
           })
-          |> child({:last_buffer_timestamp, track.id}, %LastBufferTimestamp{
+          |> child({:last_buffer_timestamp, track.id}, %EdgeTimestampSaver{
             reporter: state.reporter
           })
           |> child({:serializer, track.id}, Membrane.Stream.Serializer)

--- a/recording/lib/reporter.ex
+++ b/recording/lib/reporter.ex
@@ -21,7 +21,9 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Reporter do
   @type track_report :: %{
           type: Track.t(),
           encoding: Track.encoding(),
-          timestamp: pos_integer(),
+          offset: pos_integer(),
+          start_timestamp: pos_integer(),
+          end_timestamp: pos_integer(),
           clock_rate: Membrane.RTP.clock_rate_t(),
           metadata: any()
         }
@@ -44,14 +46,14 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Reporter do
     GenServer.cast(reporter, {:add_track, track, filename})
   end
 
-  @spec start_track(pid(), Track.id(), pos_integer()) :: :ok
-  def start_track(reporter, track_id, timestamp) do
-    GenServer.cast(reporter, {:start_track, track_id, timestamp})
+  @spec start_timestamp(pid(), Track.id(), pos_integer()) :: :ok
+  def start_timestamp(reporter, track_id, start_timestamp) do
+    GenServer.cast(reporter, {:start_timestamp, track_id, start_timestamp})
   end
 
-  @spec end_track(pid, Track.id(), pos_integer()) :: :ok
-  def end_track(reporter, track_id, end_timestamp) do
-    GenServer.cast(reporter, {:end_track, track_id, end_timestamp})
+  @spec end_timestamp(pid, Track.id(), pos_integer()) :: :ok
+  def end_timestamp(reporter, track_id, end_timestamp) do
+    GenServer.cast(reporter, {:end_timestamp, track_id, end_timestamp})
   end
 
   @spec get_report(pid()) :: report()
@@ -76,7 +78,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Reporter do
   end
 
   @impl true
-  def handle_cast({:start_track, track_id, start_timestamp}, state) do
+  def handle_cast({:start_timestamp, track_id, start_timestamp}, state) do
     state =
       update_in(state[:tracks][track_id], fn {filename, track} ->
         track =
@@ -91,7 +93,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Reporter do
   end
 
   @impl true
-  def handle_cast({:end_track, track_id, end_timestamp}, state) do
+  def handle_cast({:end_timestamp, track_id, end_timestamp}, state) do
     state =
       update_in(state[:tracks][track_id], fn {filename, track} ->
         {filename, Map.put(track, :end_timestamp, end_timestamp)}

--- a/recording/test/reporter_test.exs
+++ b/recording/test/reporter_test.exs
@@ -22,7 +22,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
     start_timestamp = 0
 
     :ok = Reporter.add_track(reporter, track, filename, start_timestamp)
-    :ok = Reporter.start_track(reporter, track.id, start_timestamp)
+    :ok = Reporter.start_timestamp(reporter, track.id, start_timestamp)
 
     assert %{
              recording_id: ^id,
@@ -40,7 +40,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
            } = Reporter.get_report(reporter)
 
     end_timestamp = 10
-    :ok = Reporter.end_track(reporter, track.id, end_timestamp)
+    :ok = Reporter.end_timestamp(reporter, track.id, end_timestamp)
 
     assert %{
              recording_id: ^id,
@@ -74,10 +74,10 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
     start_timestamp_2 = 10
 
     :ok = Reporter.add_track(reporter, track_1, filename_1, start_timestamp_1)
-    :ok = Reporter.start_track(reporter, track_1.id, start_timestamp_1)
+    :ok = Reporter.start_timestamp(reporter, track_1.id, start_timestamp_1)
 
     :ok = Reporter.add_track(reporter, track_2, filename_2, start_timestamp_2)
-    :ok = Reporter.start_track(reporter, track_2.id, start_timestamp_2)
+    :ok = Reporter.start_timestamp(reporter, track_2.id, start_timestamp_2)
 
     assert %{
              recording_id: ^id,
@@ -104,7 +104,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
            } = Reporter.get_report(reporter)
 
     end_timestamp_1 = 30
-    Reporter.end_track(reporter, track_1.id, end_timestamp_1)
+    Reporter.end_timestamp(reporter, track_1.id, end_timestamp_1)
 
     assert %{
              recording_id: ^id,
@@ -131,7 +131,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
            } = Reporter.get_report(reporter)
 
     end_timestamp_2 = 40
-    Reporter.end_track(reporter, track_2.id, end_timestamp_2)
+    Reporter.end_timestamp(reporter, track_2.id, end_timestamp_2)
 
     assert %{
              recording_id: ^id,

--- a/recording/test/reporter_test.exs
+++ b/recording/test/reporter_test.exs
@@ -19,9 +19,10 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
     track =
       %{encoding: encoding, clock_rate: clock_rate, metadata: metadata} = create_track(:video)
 
-    start_timestamp = Reporter.get_timestamp()
+    start_timestamp = 0
 
     :ok = Reporter.add_track(reporter, track, filename, start_timestamp)
+    :ok = Reporter.start_track(reporter, track.id, start_timestamp)
 
     assert %{
              recording_id: ^id,
@@ -29,20 +30,17 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                ^filename => %{
                  type: :video,
                  encoding: ^encoding,
-                 start_timestamp: 0,
-                 end_timestamp: end_timestamp,
+                 offset: ^start_timestamp,
+                 start_timestamp: ^start_timestamp,
+                 end_timestamp: ^start_timestamp,
                  clock_rate: ^clock_rate,
                  metadata: ^metadata
                }
              }
            } = Reporter.get_report(reporter)
 
-    assert end_timestamp >= 0
-
-    end_timestamp = Reporter.get_timestamp()
-    :ok = Reporter.end_track(reporter, track, end_timestamp)
-
-    end_timestamp = end_timestamp - start_timestamp
+    end_timestamp = 10
+    :ok = Reporter.end_track(reporter, track.id, end_timestamp)
 
     assert %{
              recording_id: ^id,
@@ -50,7 +48,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                ^filename => %{
                  type: :video,
                  encoding: ^encoding,
-                 start_timestamp: 0,
+                 offset: ^start_timestamp,
+                 start_timestamp: ^start_timestamp,
                  end_timestamp: ^end_timestamp,
                  clock_rate: ^clock_rate,
                  metadata: ^metadata
@@ -71,11 +70,14 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
       %{encoding: encoding_2, clock_rate: clock_rate_2, metadata: metadata_2} =
       create_track(:audio)
 
-    start_timestamp_1 = Reporter.get_timestamp()
+    start_timestamp_1 = 0
     start_timestamp_2 = 10
 
     :ok = Reporter.add_track(reporter, track_1, filename_1, start_timestamp_1)
-    :ok = Reporter.add_track(reporter, track_2, filename_2, start_timestamp_1 + start_timestamp_2)
+    :ok = Reporter.start_track(reporter, track_1.id, start_timestamp_1)
+
+    :ok = Reporter.add_track(reporter, track_2, filename_2, start_timestamp_2)
+    :ok = Reporter.start_track(reporter, track_2.id, start_timestamp_2)
 
     assert %{
              recording_id: ^id,
@@ -83,28 +85,26 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                ^filename_1 => %{
                  type: :video,
                  encoding: ^encoding_1,
-                 start_timestamp: 0,
-                 end_timestamp: end_timestamp_1,
+                 offset: ^start_timestamp_1,
+                 start_timestamp: ^start_timestamp_1,
+                 end_timestamp: ^start_timestamp_1,
                  clock_rate: ^clock_rate_1,
                  metadata: ^metadata_1
                },
                ^filename_2 => %{
                  type: :audio,
                  encoding: ^encoding_2,
+                 offset: ^start_timestamp_2,
                  start_timestamp: ^start_timestamp_2,
-                 end_timestamp: end_timestamp_2,
+                 end_timestamp: ^start_timestamp_2,
                  clock_rate: ^clock_rate_2,
                  metadata: ^metadata_2
                }
              }
            } = Reporter.get_report(reporter)
 
-    assert end_timestamp_1 >= 0
-    assert end_timestamp_2 >= 0
-
-    end_timestamp_1 = Reporter.get_timestamp()
-    Reporter.end_track(reporter, track_1, end_timestamp_1)
-    end_timestamp_1 = end_timestamp_1 - start_timestamp_1
+    end_timestamp_1 = 30
+    Reporter.end_track(reporter, track_1.id, end_timestamp_1)
 
     assert %{
              recording_id: ^id,
@@ -112,7 +112,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                ^filename_1 => %{
                  type: :video,
                  encoding: ^encoding_1,
-                 start_timestamp: 0,
+                 offset: ^start_timestamp_1,
+                 start_timestamp: ^start_timestamp_1,
                  end_timestamp: ^end_timestamp_1,
                  clock_rate: ^clock_rate_1,
                  metadata: ^metadata_1
@@ -120,18 +121,17 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                ^filename_2 => %{
                  type: :audio,
                  encoding: ^encoding_2,
+                 offset: ^start_timestamp_2,
                  start_timestamp: ^start_timestamp_2,
-                 end_timestamp: end_timestamp_2,
+                 end_timestamp: ^start_timestamp_2,
                  clock_rate: ^clock_rate_2,
                  metadata: ^metadata_2
                }
              }
            } = Reporter.get_report(reporter)
 
-    assert end_timestamp_2 >= 0
-    end_timestamp_2 = Reporter.get_timestamp()
-    Reporter.end_track(reporter, track_2, end_timestamp_2)
-    end_timestamp_2 = end_timestamp_2 - start_timestamp_1
+    end_timestamp_2 = 40
+    Reporter.end_track(reporter, track_2.id, end_timestamp_2)
 
     assert %{
              recording_id: ^id,
@@ -139,7 +139,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                ^filename_1 => %{
                  type: :video,
                  encoding: ^encoding_1,
-                 start_timestamp: 0,
+                 offset: ^start_timestamp_1,
+                 start_timestamp: ^start_timestamp_1,
                  end_timestamp: ^end_timestamp_1,
                  clock_rate: ^clock_rate_1,
                  metadata: ^metadata_1
@@ -147,6 +148,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                ^filename_2 => %{
                  type: :audio,
                  encoding: ^encoding_2,
+                 offset: ^start_timestamp_2,
                  start_timestamp: ^start_timestamp_2,
                  end_timestamp: ^end_timestamp_2,
                  clock_rate: ^clock_rate_2,

--- a/recording/test/storage/file_test.exs
+++ b/recording/test/storage/file_test.exs
@@ -25,7 +25,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Storage.FileTest do
 
   @tag :tmp_dir
   test "save report", %{tmp_dir: output_dir} do
-    {:ok, reporter} = Reporter.start(UUID.uuid4())
+    recording_id = UUID.uuid4()
+    {:ok, reporter} = Reporter.start(recording_id)
 
     filename = "track_1.msr"
     track = create_track(:video)

--- a/recording/test/storage/s3_test.exs
+++ b/recording/test/storage/s3_test.exs
@@ -51,7 +51,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Storage.S3Test do
     offset = 0
 
     :ok = Reporter.add_track(reporter, track, filename, offset)
-    :ok = Reporter.start_track(reporter, track.id, offset)
+    :ok = Reporter.start_timestamp(reporter, track.id, offset)
 
     report_json =
       reporter

--- a/recording/test/storage/s3_test.exs
+++ b/recording/test/storage/s3_test.exs
@@ -51,6 +51,7 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Storage.S3Test do
     offset = 0
 
     :ok = Reporter.add_track(reporter, track, filename, offset)
+    :ok = Reporter.start_track(reporter, track.id, offset)
 
     report_json =
       reporter

--- a/recording/test/support/mock_track.ex
+++ b/recording/test/support/mock_track.ex
@@ -9,7 +9,7 @@ defmodule MockTrack do
     %Track{
       type: type,
       stream_id: "stream_id",
-      id: "id",
+      id: "id_#{type}",
       origin: "origin",
       fmtp: %FMTP{pt: nil},
       encoding: :h264,


### PR DESCRIPTION
In the recording report, we need the start timestamp and end timestamp of the track.