### PR TITLE
Recording Endpoint: add origin to report

### DIFF
--- a/recording/CHANGELOG.md
+++ b/recording/CHANGELOG.md
@@ -14,4 +14,4 @@
 * Use engine manual and auto subscribe mode. [#383](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/383)
 * Fix membrane_core version used in mixfile [#385](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/385)
 * Change use of ResourceGuard [#386](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/386)
-* Add origin to tne report [#387](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/387)
+* Add origin to the report [#387](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/387)

--- a/recording/CHANGELOG.md
+++ b/recording/CHANGELOG.md
@@ -14,3 +14,4 @@
 * Use engine manual and auto subscribe mode. [#383](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/383)
 * Fix membrane_core version used in mixfile [#385](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/385)
 * Change use of ResourceGuard [#386](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/386)
+* Add origin to tne report [#387](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/387)

--- a/recording/lib/reporter.ex
+++ b/recording/lib/reporter.ex
@@ -14,7 +14,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Reporter do
     :start_timestamp,
     :end_timestamp,
     :clock_rate,
-    :metadata
+    :metadata,
+    :origin
   ]
 
   @type filename :: String.t()
@@ -25,7 +26,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Reporter do
           start_timestamp: pos_integer(),
           end_timestamp: pos_integer(),
           clock_rate: Membrane.RTP.clock_rate_t(),
-          metadata: any()
+          metadata: any(),
+          origin: String.t()
         }
   @type report :: %{
           recording_id: String.t(),

--- a/recording/test/reporter_test.exs
+++ b/recording/test/reporter_test.exs
@@ -17,7 +17,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
     filename = "track_1.msr"
 
     track =
-      %{encoding: encoding, clock_rate: clock_rate, metadata: metadata} = create_track(:video)
+      %{encoding: encoding, clock_rate: clock_rate, metadata: metadata, origin: origin} =
+      create_track(:video)
 
     start_timestamp = 0
 
@@ -34,7 +35,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp,
                  end_timestamp: ^start_timestamp,
                  clock_rate: ^clock_rate,
-                 metadata: ^metadata
+                 metadata: ^metadata,
+                 origin: ^origin
                }
              }
            } = Reporter.get_report(reporter)
@@ -52,7 +54,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp,
                  end_timestamp: ^end_timestamp,
                  clock_rate: ^clock_rate,
-                 metadata: ^metadata
+                 metadata: ^metadata,
+                 origin: ^origin
                }
              }
            } = Reporter.get_report(reporter)
@@ -63,11 +66,11 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
     filename_2 = "track_2.msr"
 
     track_1 =
-      %{encoding: encoding_1, clock_rate: clock_rate_1, metadata: metadata_1} =
+      %{encoding: encoding_1, clock_rate: clock_rate_1, metadata: metadata_1, origin: origin_1} =
       create_track(:video)
 
     track_2 =
-      %{encoding: encoding_2, clock_rate: clock_rate_2, metadata: metadata_2} =
+      %{encoding: encoding_2, clock_rate: clock_rate_2, metadata: metadata_2, origin: origin_2} =
       create_track(:audio)
 
     start_timestamp_1 = 0
@@ -89,7 +92,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp_1,
                  end_timestamp: ^start_timestamp_1,
                  clock_rate: ^clock_rate_1,
-                 metadata: ^metadata_1
+                 metadata: ^metadata_1,
+                 origin: ^origin_1
                },
                ^filename_2 => %{
                  type: :audio,
@@ -98,7 +102,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp_2,
                  end_timestamp: ^start_timestamp_2,
                  clock_rate: ^clock_rate_2,
-                 metadata: ^metadata_2
+                 metadata: ^metadata_2,
+                 origin: ^origin_2
                }
              }
            } = Reporter.get_report(reporter)
@@ -116,7 +121,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp_1,
                  end_timestamp: ^end_timestamp_1,
                  clock_rate: ^clock_rate_1,
-                 metadata: ^metadata_1
+                 metadata: ^metadata_1,
+                 origin: ^origin_1
                },
                ^filename_2 => %{
                  type: :audio,
@@ -125,7 +131,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp_2,
                  end_timestamp: ^start_timestamp_2,
                  clock_rate: ^clock_rate_2,
-                 metadata: ^metadata_2
+                 metadata: ^metadata_2,
+                 origin: ^origin_2
                }
              }
            } = Reporter.get_report(reporter)
@@ -143,7 +150,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp_1,
                  end_timestamp: ^end_timestamp_1,
                  clock_rate: ^clock_rate_1,
-                 metadata: ^metadata_1
+                 metadata: ^metadata_1,
+                 origin: origin_1
                },
                ^filename_2 => %{
                  type: :audio,
@@ -152,7 +160,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.ReporterTest do
                  start_timestamp: ^start_timestamp_2,
                  end_timestamp: ^end_timestamp_2,
                  clock_rate: ^clock_rate_2,
-                 metadata: ^metadata_2
+                 metadata: ^metadata_2,
+                 origin: origin_2
                }
              }
            } = Reporter.get_report(reporter)


### PR DESCRIPTION
The origin field in report is necessary to pair audio and video tracks 